### PR TITLE
Replacing "_" by "/" on default image name to handle ControlMaster on…

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ $ docker run --privileged -v /var/lib/docker:/var/lib/docker -it --rm -p 2222:22
 
 ### master (unreleased)
 
+* Replacing "_" by "/" on default image name to handle ControlMaster on clients
 * Support of `--banner` option ([#26](https://github.com/moul/ssh2docker/issues/26))
 * Add a not-yet-implemented warning for exec ([#51](https://github.com/moul/ssh2docker/issues/51))
 * Support of `--local-user` option, to allow a specific user to be a local shell ([#44](https://github.com/moul/ssh2docker/issues/44))

--- a/client.go
+++ b/client.go
@@ -57,7 +57,7 @@ func NewClient(conn *ssh.ServerConn, chans <-chan ssh.NewChannel, reqs <-chan *s
 
 		// Default ClientConfig, will be overwritten if a hook is used
 		Config: &ClientConfig{
-			ImageName:  conn.User(),
+			ImageName:  strings.Replace(conn.User(), "_", "/", -1),
 			RemoteUser: "anonymous",
 		},
 	}


### PR DESCRIPTION
… clients